### PR TITLE
Update CI deployment branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ script: "lektor build"
 deploy:
   provider: script
   script: "lektor deploy ghpages"
+  on:
+    branch: main


### PR DESCRIPTION
Travis uses `master` as the default branch and I renamed it to `main`.